### PR TITLE
Fix untoldone/bloomapi issue #38

### DIFF
--- a/make.js
+++ b/make.js
@@ -44,6 +44,15 @@ target.bootstrap = function () {
     .then(function (data) {
       return Q.ninvoke(pg, 'query', data);
     })
+    .fail(function (e) {
+      if(e.code == '42710'){ // "DUPLICATE OBJECT" according to http://www.postgresql.org/docs/9.0/static/errcodes-appendix.html
+        logger.data.info("looks like you already have the database schema set up. (bootstrap assumes you don't.)")
+        logger.data.info("if you need to update the NPI data, simply run `node make fetch`")
+      } else {
+        console.error("Error:\n", e.stack);
+        process.exit(1);
+      }
+    })
     .then(npi.update)
     .fail(function (e) {
       console.error("Error:\n", e.stack);


### PR DESCRIPTION
@untoldone - this should fix it. I'm no Q/deferred genius still but I think it makes sense. Unfortunately using the error code seems to be the best way to catch this. A log of the error object isn't too descriptive (below) and I didn't want to make it dependent on the `source_status` field.

```
{ [error: type "source_status" already exists]
  length: 86,
  name: 'error',
  severity: 'ERROR',
  code: '42710',
  detail: undefined,
  hint: undefined,
  position: undefined,
  internalPosition: undefined,
  internalQuery: undefined,
  where: undefined,
  file: 'typecmds.c',
  line: '1084',
  routine: 'DefineEnum' }

```
