### PR TITLE
fixes for Github #32 and #34, adding ip of source of x_forwarded_for and response time of nginx to access_log

### DIFF
--- a/ansible/roles/bloomapi/files/nginx.conf
+++ b/ansible/roles/bloomapi/files/nginx.conf
@@ -1,0 +1,100 @@
+user www-data;
+worker_processes 4;
+pid /run/nginx.pid;
+
+events {
+	worker_connections 768;
+	# multi_accept on;
+}
+
+http {
+
+	##
+	# Basic Settings
+	##
+
+	sendfile on;
+	tcp_nopush on;
+	tcp_nodelay on;
+	keepalive_timeout 65;
+	types_hash_max_size 2048;
+	# server_tokens off;
+
+	# server_names_hash_bucket_size 64;
+	# server_name_in_redirect off;
+
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
+
+	##
+	# Logging Settings
+	##
+
+  log_format main '$remote_addr - $remote_user [$time_local]  $status '
+    '"$request" $body_bytes_sent "$http_referer" '
+    '"$http_user_agent" $http_x_forwarded_for '
+    '$request_time $upstream_response_time $pipe';
+
+	access_log /var/log/nginx/access.log main;
+	error_log /var/log/nginx/error.log;
+
+	##
+	# Gzip Settings
+	##
+
+	gzip on;
+	gzip_disable "msie6";
+
+	# gzip_vary on;
+	# gzip_proxied any;
+	# gzip_comp_level 6;
+	# gzip_buffers 16 8k;
+	# gzip_http_version 1.1;
+	# gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+	##
+	# nginx-naxsi config
+	##
+	# Uncomment it if you installed nginx-naxsi
+	##
+
+	#include /etc/nginx/naxsi_core.rules;
+
+	##
+	# nginx-passenger config
+	##
+	# Uncomment it if you installed nginx-passenger
+	##
+	
+	#passenger_root /usr;
+	#passenger_ruby /usr/bin/ruby;
+
+	##
+	# Virtual Host Configs
+	##
+
+	include /etc/nginx/conf.d/*.conf;
+	include /etc/nginx/sites-enabled/*;
+}
+
+
+#mail {
+#	# See sample authentication script at:
+#	# http://wiki.nginx.org/ImapAuthenticateWithApachePhpScript
+# 
+#	# auth_http localhost/auth.php;
+#	# pop3_capabilities "TOP" "USER";
+#	# imap_capabilities "IMAP4rev1" "UIDPLUS";
+# 
+#	server {
+#		listen     localhost:110;
+#		protocol   pop3;
+#		proxy      on;
+#	}
+# 
+#	server {
+#		listen     localhost:143;
+#		protocol   imap;
+#		proxy      on;
+#	}
+#}

--- a/ansible/roles/bloomapi/tasks/main.yml
+++ b/ansible/roles/bloomapi/tasks/main.yml
@@ -24,6 +24,11 @@
     - restart bloomapi
 
 - name: be sure nginx is configured
+  copy: src=nginx.conf dest=/etc/nginx/nginx.conf owner=root group=root mode=644
+  notify:
+    - restart nginx
+  sudo: yes
+- name: be sure nginx default site is configured
   template: src=nginx_default_site dest=/etc/nginx/sites-available/default
   notify:
     - restart nginx


### PR DESCRIPTION
Adds more useful metadata to nginx access logs.

Noteworthy lines in nginx.conf are the ones in the "Logging Settings" area. All other lines are from the default nginx apt package on ubuntu.
